### PR TITLE
Disable legacy compatibility mode when formatting

### DIFF
--- a/src/services/yamlFormatter.ts
+++ b/src/services/yamlFormatter.ts
@@ -10,13 +10,15 @@ export function format(document: TextDocument, options: FormattingOptions): Text
     const documents = []
     jsyaml.loadAll(text, doc => documents.push(doc))
 
+    const dumpOptions = { indent: options.tabSize, noCompatMode: true };
+
     let newText;
     if (documents.length == 1) {
         const yaml = documents[0]
-        newText = jsyaml.safeDump(yaml, { indent: options.tabSize })
+        newText = jsyaml.safeDump(yaml, dumpOptions)
     }
     else {
-        const formatted = documents.map(d => jsyaml.safeDump(d, { indent: options.tabSize }))
+        const formatted = documents.map(d => jsyaml.safeDump(d, dumpOptions))
         newText = '%YAML 1.2' + EOL + '---' + EOL + formatted.join('...' + EOL + '---' + EOL) + '...' + EOL
     }
 

--- a/src/test/yamlFormatter.test.ts
+++ b/src/test/yamlFormatter.test.ts
@@ -100,4 +100,10 @@ suite("YAML Formatter", () => {
 ...
 `)
   })
+
+  test("outputs yaml 1.2", () => {
+    assertFormatedEqual(`on: {tags: true}`, `on:
+  tags: true
+`)
+  })
 })


### PR DESCRIPTION
This extension treats YAML files as YAML 1.2 but when formatting was escaping some members to be compatible with older versions of YAML.  This created displeasing results in files such as .travis.yml.  This change removes this unnecessary behavior.