### PR TITLE
Breakage due to changes of (internal) dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "js-yaml": "^3.8.4",
     "jsonc-parser": "^1.0.0",
-    "vscode-json-languageservice": "^2.0.14",
+    "vscode-json-languageservice": "2.0.14",
     "vscode-nls": "^2.0.2",
     "yaml-ast-parser": "0.0.34"
   },


### PR DESCRIPTION
vscode-yaml-languageservice uses internal API of vscode-json-languageservice and is broken due to changes of these types.
See https://github.com/Microsoft/vscode-json-languageservice/pull/18

The quick fix is to depend on a fixed version of vscode-json-languageservice.

In the long term we should work on making real API in vscode-json-languageservice